### PR TITLE
Fix use of undocumented chalk.stripAnsi

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -8,6 +8,7 @@ const EventEmitter = require('events').EventEmitter;
 const debug = require('debug')('connector');
 const through2 = require('through2');
 const chalk = require('chalk');
+const stripAnsi = require('strip-ansi');
 const path = require('path');
 const fse = require('fs-extra');
 const ipc = require('./lib/ipc');
@@ -178,7 +179,7 @@ class Connector extends EventEmitter {
 
       if (this.readlineServerDisabled) return;
 
-      line = chalk.stripColor(line.trim());
+      line = stripAnsi(line.trim());
 
       // console.log("LINE", JSON.stringify(line));
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "chalk": "^3.0.0",
     "co": "^4.6.0",
     "debug": "^2.2.0",
     "fs-extra": "^0.28.0",
@@ -20,6 +21,7 @@
     "lodash": "^4.11.1",
     "node-ipc": "^7.0.0",
     "node-notifier": "^4.5.0",
+    "strip-ansi": "^6.0.0",
     "telnet-stream": "0.0.4",
     "through2": "^2.0.1"
   }


### PR DESCRIPTION
Add chalk package dependency. Add strip-ansi dependency to replace
chalk.stripColor which was removed.

Discussion of chalk.stripColor: https://github.com/chalk/chalk/issues/119